### PR TITLE
Fixed missing argparse python module in CentOS tdl

### DIFF
--- a/heat_jeos/jeos/CentOS-6.3-x86_64-cfntools.tdl
+++ b/heat_jeos/jeos/CentOS-6.3-x86_64-cfntools.tdl
@@ -34,6 +34,7 @@ yum -y update
 curl -O http://ftp.ps.pl/pub/Linux/fedora-epel/6/i386/epel-release-6-7.noarch.rpm
 rpm -Uvh epel-release-6-7.noarch.rpm
 yum -y install perl python python-setuptools cloud-init
+easy_install argparse
 rm -f epel-release-6-7.noarch.rpm
     </command>
     <command name='cfn-perms'>


### PR DESCRIPTION
VM was starting and registering ssh key properly, but launching /opt/aws/cfn-init was failing because of missing python module.

https://rackspace.echosign.com/public/audit?tx=ZGCSZWDXR3S4LW
Signed-off-by: Maciej Osyda maciej.osyda@amg.net.pl
