### PR TITLE
Fix invalid XML in CentOS-6.3-x86_64-cfntools.tdl

### DIFF
--- a/heat_jeos/jeos/CentOS-6.3-x86_64-cfntools.tdl
+++ b/heat_jeos/jeos/CentOS-6.3-x86_64-cfntools.tdl
@@ -18,6 +18,7 @@ NM_CONTROLLED="yes"
 ONBOOT="yes"
 EOF
     </command>
+    <command>
 chmod +x /etc/rc.d/rc.local
     </command>
     <command name='packages'>


### PR DESCRIPTION
The examples given in the documentation die with a thoroughly unhelpful error because of this.
