### PR TITLE
Add option to set an image to private

### DIFF
--- a/bin/heat-jeos
+++ b/bin/heat-jeos
@@ -198,7 +198,7 @@ def command_create(options, arguments):
                 logging.info('No action taken')
                 sys.exit(0)
         image_id = glance.register_image(client, qcow2_path, image_name,
-                                  options.username, image)
+                                  options, image)
         print('\nImage %s was registered with ID %s' % (image_name, image_id))
     except glance.ConnectionError, e:
         logging.error('Failed to connect to the Glance API server.')
@@ -253,6 +253,9 @@ def create_options(parser):
     parser.add_option('-H', '--glance-host',
                       default=None,
                       help="Glance hostname")
+    parser.add_option('-p', '--private',
+                      default=False, action="store_true",
+                      help="Sets glance image to private instead of public")
     parser.add_option('-P', '--glance-port',
                       default=None,
                       help="Glance port number")

--- a/heat_jeos/glance_clients.py
+++ b/heat_jeos/glance_clients.py
@@ -122,12 +122,15 @@ def create_image_folsom(client, image_meta, image_file):
     return vars(image)
 
 
-def register_image(client, qcow2_path, name, owner, existing_image):
+def register_image(client, qcow2_path, name, options, existing_image):
     """
     Register the given image with Glance.
     """
+    owner = options.username
+    is_public = not options.private
+
     image_meta = {'name': name,
-                  'is_public': True,
+                  'is_public': is_public,
                   'disk_format': 'qcow2',
                   'min_disk': 0,
                   'min_ram': 0,


### PR DESCRIPTION
Hi, we want to do some testruns before publishing an image into the cloud for all users. This adds the option -p to upload a non-public image.
