### PR TITLE
Update CentOS-6.3-x86_64-cfntools.tdl

### DIFF
--- a/heat_jeos/jeos/CentOS-6.3-x86_64-cfntools.tdl
+++ b/heat_jeos/jeos/CentOS-6.3-x86_64-cfntools.tdl
@@ -10,7 +10,7 @@
   </os>
   <description>CentOS 6.3</description>
   <commands>
-    <command>
+    <command name='set root pw'>
 passwd -l root
     </command>
     <command name='network-config'>
@@ -21,6 +21,7 @@ NM_CONTROLLED="yes"
 ONBOOT="yes"
 EOF
     </command>
+    <command name='chmod rc.local'>
 chmod +x /etc/rc.d/rc.local
     </command>
     <command name='packages'>

--- a/heat_jeos/jeos/CentOS-6.5-x86_64-cfntools.tdl
+++ b/heat_jeos/jeos/CentOS-6.5-x86_64-cfntools.tdl
@@ -1,0 +1,41 @@
+<template>
+  <name>CentOS-6.3-x86_64-cfntools</name>
+  <os>
+    <name>CentOS-6</name>
+    <version>3</version>
+    <arch>x86_64</arch>
+    <install type='iso'>
+      <iso>file:/var/lib/libvirt/images/CentOS-6.5-x86_64-bin-DVD1.iso</iso>
+    </install>
+  </os>
+  <description>CentOS 6.5</description>
+  <commands>
+    <command name='set root pw'>
+passwd -l root
+    </command>
+    <command name='network-config'>
+cat > /etc/sysconfig/network-scripts/ifcfg-eth0 &lt;&lt; EOF
+DEVICE="eth0"
+BOOTPROTO=dhcp
+NM_CONTROLLED="yes"
+ONBOOT="yes"
+EOF
+    </command>
+    <command name='chmod rc.local'>
+chmod +x /etc/rc.d/rc.local
+    </command>
+    <command name='packages'>
+yum -y update
+curl -O http://ftp.ps.pl/pub/Linux/fedora-epel/6/x86_64/epel-release-6-7.noarch.rpm
+rpm -Uvh epel-release-6-7.noarch.rpm
+yum -y install perl python python-setuptools cloud-init python-pip
+pip-python install argparse 'boto==2.5.2' heat-cfntools
+cfn-create-aws-symlinks --source /usr/bin
+rm -f epel-release-6-7.noarch.rpm
+    </command>
+    <command name='post-configuration'>
+chkconfig --level 345 sshd on
+rm -rf /etc/udev/rules.d/70-persistent-net.rules
+    </command>
+  </commands>
+</template>

--- a/heat_jeos/jeos/F19-i386-cfntools.tdl
+++ b/heat_jeos/jeos/F19-i386-cfntools.tdl
@@ -1,0 +1,29 @@
+<template>
+  <name>F19-i386-cfntools</name>
+  <os>
+    <name>Fedora</name>
+    <version>19</version>
+    <arch>i386</arch>
+    <install type='iso'>
+      <iso>file:/var/lib/libvirt/images/Fedora-19-i386-DVD.iso</iso>
+    </install>
+  </os>
+  <description>Fedora 19</description>
+  <commands>
+    <command>
+passwd -l root
+    </command>
+    <command name='packages'>
+yum -y update fedora-release
+yum -y install yum-plugin-fastestmirror cloud-init python-psutil python-pip python-boto
+yum -y update
+sed --in-place -e s/Type=oneshot/"Type=oneshot\nTimeoutSec=0"/ /lib/systemd/system/cloud-final.service
+pip-python install heat-cfntools
+cfn-create-aws-symlinks --source /usr/bin
+
+    </command>
+    <command name='firewall'>
+systemctl disable firewalld.service
+    </command>
+  </commands>
+</template>

--- a/heat_jeos/jeos/F19-x86_64-cfntools.tdl
+++ b/heat_jeos/jeos/F19-x86_64-cfntools.tdl
@@ -1,0 +1,29 @@
+<template>
+  <name>F19-x86_64-cfntools</name>
+  <os>
+    <name>Fedora</name>
+    <version>19</version>
+    <arch>x86_64</arch>
+    <install type='iso'>
+      <iso>file:/var/lib/libvirt/images/Fedora-19-x86_64-DVD.iso</iso>
+    </install>
+  </os>
+  <description>Fedora 19</description>
+  <commands>
+    <command>
+passwd -l root
+    </command>
+    <command name='packages'>
+yum -y update fedora-release
+yum -y install yum-plugin-fastestmirror cloud-init python-psutil python-pip python-boto
+yum -y update
+sed --in-place -e s/Type=oneshot/"Type=oneshot\nTimeoutSec=0"/ /lib/systemd/system/cloud-final.service
+pip-python install heat-cfntools
+cfn-create-aws-symlinks --source /usr/bin
+
+    </command>
+    <command name='firewall'>
+systemctl disable firewalld.service
+    </command>
+  </commands>
+</template>

--- a/heat_jeos/jeos/F20-i386-cfntools.tdl
+++ b/heat_jeos/jeos/F20-i386-cfntools.tdl
@@ -1,0 +1,29 @@
+<template>
+  <name>F20-i386-cfntools</name>
+  <os>
+    <name>Fedora</name>
+    <version>20</version>
+    <arch>i386</arch>
+    <install type='iso'>
+      <iso>file:/var/lib/libvirt/images/Fedora-20-i386-DVD.iso</iso>
+    </install>
+  </os>
+  <description>Fedora 20</description>
+  <commands>
+    <command>
+passwd -l root
+    </command>
+    <command name='packages'>
+yum -y update fedora-release
+yum -y install yum-plugin-fastestmirror cloud-init python-psutil python-pip python-boto
+yum -y update
+sed --in-place -e s/Type=oneshot/"Type=oneshot\nTimeoutSec=0"/ /lib/systemd/system/cloud-final.service
+pip-python install heat-cfntools
+cfn-create-aws-symlinks --source /usr/bin
+
+    </command>
+    <command name='firewall'>
+systemctl disable firewalld.service
+    </command>
+  </commands>
+</template>

--- a/heat_jeos/jeos/F20-x86_64-cfntools.tdl
+++ b/heat_jeos/jeos/F20-x86_64-cfntools.tdl
@@ -1,0 +1,29 @@
+<template>
+  <name>F20-x86_64-cfntools</name>
+  <os>
+    <name>Fedora</name>
+    <version>20</version>
+    <arch>x86_64</arch>
+    <install type='iso'>
+      <iso>file:/var/lib/libvirt/images/Fedora-20-x86_64-DVD.iso</iso>
+    </install>
+  </os>
+  <description>Fedora 20</description>
+  <commands>
+    <command>
+passwd -l root
+    </command>
+    <command name='packages'>
+yum -y update fedora-release
+yum -y install yum-plugin-fastestmirror cloud-init python-psutil python-pip python-boto
+yum -y update
+sed --in-place -e s/Type=oneshot/"Type=oneshot\nTimeoutSec=0"/ /lib/systemd/system/cloud-final.service
+pip-python install heat-cfntools
+cfn-create-aws-symlinks --source /usr/bin
+
+    </command>
+    <command name='firewall'>
+systemctl disable firewalld.service
+    </command>
+  </commands>
+</template>


### PR DESCRIPTION
fixed missing <command> tag and added name attributes to command tags, oz complains about the missing attributes when launched.
