### PR TITLE
Update CentOS-6.5-x86_64-cfntools.tdl

### DIFF
--- a/heat_jeos/jeos/CentOS-6.5-x86_64-cfntools.tdl
+++ b/heat_jeos/jeos/CentOS-6.5-x86_64-cfntools.tdl
@@ -1,5 +1,5 @@
 <template>
-  <name>CentOS-6.3-x86_64-cfntools</name>
+  <name>CentOS-6.5-x86_64-cfntools</name>
   <os>
     <name>CentOS-6</name>
     <version>3</version>


### PR DESCRIPTION
 Changed
<name>CentOS-6.3-x86_64-cfntools</name>
to
 <name>CentOS-6.5-x86_64-cfntools</name>
